### PR TITLE
Making Cometd compatible with Grails 1.2.1

### DIFF
--- a/CometdGrailsPlugin.groovy
+++ b/CometdGrailsPlugin.groovy
@@ -26,7 +26,7 @@ import org.springframework.web.context.support.ServletContextAttributeExporter
 
 class CometdGrailsPlugin {
     def version = "0.2.1"
-    def grailsVersion = "1.3.1 > *"
+    def grailsVersion = "1.2.1 > *"
     def dependsOn = [:]
     def pluginExcludes = [
         'grails-app/services/**/test/',

--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,9 @@
 #Grails Metadata file
-#Thu Jun 03 06:56:25 CEST 2010
-app.grails.version=1.3.1
+#Mon Oct 18 15:09:48 CEST 2010
+app.grails.version=1.2.1
 app.name=grails-cometd
 app.servlet.version=2.4
 app.version=0.1
 plugins.functional-test=1.2.7
-plugins.hibernate=1.3.1
-plugins.tomcat=1.3.1
+plugins.hibernate=1.2.1
+plugins.tomcat=1.2.1

--- a/application.properties
+++ b/application.properties
@@ -1,9 +1,9 @@
 #Grails Metadata file
-#Mon Oct 18 15:09:48 CEST 2010
-app.grails.version=1.2.1
+#Thu Jun 03 06:56:25 CEST 2010
+app.grails.version=1.3.1
 app.name=grails-cometd
 app.servlet.version=2.4
 app.version=0.1
 plugins.functional-test=1.2.7
-plugins.hibernate=1.2.1
-plugins.tomcat=1.2.1
+plugins.hibernate=1.3.1
+plugins.tomcat=1.3.1

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -21,9 +21,6 @@ grails.project.dependency.resolution = {
     inherits 'global'
     log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     repositories {        
-        grailsPlugins()
-        grailsHome()
-        grailsCentral()
         mavenCentral()
     }
     dependencies {


### PR DESCRIPTION
Hi,
As at my company we are using Grails 1.2.1 and we recently upgraded to the latest version of Comet. As the one published is compatible with 1.3.1 and above, I took your code and gave it a look. In fact it was simple to make it compatible with 1.2.1, I only made two minor changes: I removed the references to Grails plugins repos in BuildConfig.groovy (they do not exist yet in 1.2.1) and I updated CometdGrailsPlugin.groovy. 

We are using it now. As it works, I thought maybe you would like to have this work.

Cheers,

Antoine
